### PR TITLE
Avoid port conflicts and allow hosting of Firmware, App and Weather on same local RPi

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,11 +3,14 @@ var express		= require( "express" ),
     mongoose	= require( "mongoose" ),
     Cache		= require( "./models/Cache" ),
     CronJob		= require( "cron" ).CronJob,
+	host		= process.env.HOST || "127.0.0.1",
 	port		= process.env.PORT || 3000,
 	app			= express();
 
-if ( !process.env.PORT ) {
+if ( !process.env.HOST || !process.env.PORT ) {
 	require( "dotenv" ).load();
+	host = process.env.HOST || host;
+	port = process.env.PORT || port;
 }
 
 // Connect to local MongoDB instance
@@ -24,6 +27,10 @@ mongoose.connection.on( "error", function() {
 app.get( /weather(\d+)\.py/, weather.getWeather );
 app.get( /(\d+)/, weather.getWeather );
 
+app.get('/', function (req, res) {
+  res.send('OpenSprinkler Weather Service');
+});
+
 // Handle 404 error
 app.use( function( req, res ) {
 	res.status( 404 );
@@ -31,9 +38,8 @@ app.use( function( req, res ) {
 } );
 
 // Start listening on the service port
-app.listen( port, "127.0.0.1", function() {
-
-  console.log( "OpenSprinkler Weather Service now listening on port %s", port );
+app.listen( port, host, function() {
+  console.log( "OpenSprinkler Weather Service now listening on %s:%s", host, port );
 } );
 
 // Schedule a cronjob daily to consildate the weather cache data, runs daily


### PR DESCRIPTION
Ray/Samer,

A joint pull-request to allow for Firmware, App and Weather servers to co-exist on the same local RPi2 box and avoid port conflict i.e. port 80 is used for both weather calls and UI page requests.

In order to do this, I needed to make a few small changes to server.js in Weather and weather.cpp in Firmware as follows:

1. Modified weather.cpp to parse both host and port from the specified weather url, i.e. allowing “localhost:3000” to be entered in the /su dialog. 
2. Modified server.js to allow both HOST and PORT to be specified in a .env file and set the precedence to be 1) environment variable, 2) .env file, 3) hardcoded default. This also allows HOST to be set to 0.0.0.0 giving access to the service from more than just localhost.
3. [Optional] Added a few additional pieces to help with diagnosing the set-up:
a.	Modified server.js to publish a service statement, “OpenSprinkler Weather Service”, when hit on the default page “/”.
b.	Modified weather.cpp to provide more diagnostic information on the connected server.

As an example, point 3 was helpful in figuring out that Debian translates “hostname” to 127.0.1.1 but “localhost” goes to 127.0.0.1. I hadn’t seen that before.

I don’t believe that any of the above changes would modify the default behavior but allow for more customised configurations for the users.
