### PR TITLE
Add endpoint for WU format weather station

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -397,6 +397,14 @@
         "vary": "^1"
       }
     },
+    "cron": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.7.1.tgz",
+      "integrity": "sha512-gmMB/pJcqUVs/NklR1sCGlNYM7TizEw+1gebz20BMc/8bTm/r7QUp3ZPSPlG8Z5XRlvb7qhjEjq/+bdIfUCL2A==",
+      "requires": {
+        "moment-timezone": "^0.5.x"
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "os-weather-service",
   "description": "OpenSprinkler Weather Service",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": "https://github.com/OpenSprinkler/Weather-Weather",
   "scripts": {
     "test": "mocha --exit test",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
+    "cron": "^1.3.0",
     "dotenv": "^6.2.0",
     "express": "^4.16.4",
     "geo-tz": "^4.0.2",

--- a/routes/local.js
+++ b/routes/local.js
@@ -1,0 +1,62 @@
+var CronJob = require( "cron" ).CronJob;
+var server = require( "../server.js" );
+var today = {}, yesterday = {};
+var count = { temp: 0, humidity: 0 };
+var current_date = new Date();
+var last_rain = new Date().setTime(0);
+
+function sameDay(d1, d2) {
+	return d1.getFullYear() === d2.getFullYear() &&
+			d1.getMonth() === d2.getMonth() &&
+			d1.getDate() === d2.getDate();
+}
+
+exports.captureWUStream = function( req, res ) {
+	var prev, curr;
+
+	if ( !( "dateutc" in req.query ) || !sameDay( current_date, new Date( req.query.dateutc + "Z") )) {
+		res.send( "Error: Bad date range\n" );
+		return;
+	}
+
+	if ( ( "tempf" in req.query ) && !isNaN( curr = parseFloat( req.query.tempf ) ) && curr !== -9999.0 ) {
+		prev = ( "temp" in today ) ? today.temp : 0;
+		today.temp = ( prev * count.temp + curr ) / ( ++count.temp );
+	}
+	if ( ( "humidity" in req.query ) && !isNaN( curr = parseFloat( req.query.humidity ) ) && curr !== -9999.0 ) {
+		prev = ( "humidity" in today ) ? today.humidity : 0;
+		today.humidity = ( prev * count.humidity + curr ) / ( ++count.humidity );
+	}
+	if ( ( "dailyrainin" in req.query ) && !isNaN( curr = parseFloat( req.query.dailyrainin ) ) && curr !== -9999.0 ) {
+		today.precip = curr;
+	}
+	if ( ( "rainin" in req.query ) && !isNaN( curr = parseFloat( req.query.rainin ) ) && curr > 0 ) {
+		last_rain = new Date();
+	}
+
+	res.send( "success\n" );
+};
+
+exports.hasLocalWeather = function() {
+	return ( server.pws !== "false" ? true : false );
+};
+
+exports.getLocalWeather = function() {
+	var result = {};
+
+	// Use today's weather if we dont have information for yesterday yet (i.e. on startup)
+	Object.assign( result, today, yesterday);
+	Object.assign( result, ( yesterday.precip && today.precip ) ? { precip: yesterday.precip + today.precip } : {} );
+
+	result.raining = ( ( Date.now() - last_rain ) / 1000 / 60 / 60 < 1 );
+
+	return result;
+};
+
+new CronJob( "0 0 0 * * *", function() {
+
+	yesterday = Object.assign( {}, today );
+	today = Object.assign( {} );
+	count.temp = 0; count.humidity = 0;
+	current_date = new Date();
+}, null, true );

--- a/routes/local.js
+++ b/routes/local.js
@@ -37,7 +37,7 @@ exports.captureWUStream = function( req, res ) {
 	res.send( "success\n" );
 };
 
-exports.hasLocalWeather = function() {
+exports.useLocalWeather = function() {
 	return ( server.pws !== "false" ? true : false );
 };
 

--- a/routes/weather.js
+++ b/routes/weather.js
@@ -168,9 +168,8 @@ function calculateWeatherScale( adjustmentMethod, adjustmentOptions, weather ) {
 			precipBase = adjustmentOptions.hasOwnProperty( "br" ) ? adjustmentOptions.br : precipBase;
 		}
 
-		var temp = ( ( weather.maxTemp + weather.minTemp ) / 2 ) || weather.temp,
-			humidityFactor = ( humidityBase - weather.humidity ),
-			tempFactor = ( ( temp - tempBase ) * 4 ),
+		var humidityFactor = ( humidityBase - weather.humidity ),
+			tempFactor = ( ( weather.temp - tempBase ) * 4 ),
 			precipFactor = ( ( precipBase - weather.precip ) * 200 );
 
 		// Apply adjustment options, if provided, by multiplying the percentage against the factor

--- a/server.js
+++ b/server.js
@@ -1,14 +1,17 @@
 var express		= require( "express" ),
 	weather		= require( "./routes/weather.js" ),
+	local		= require( "./routes/local.js" ),
 	cors		= require( "cors" ),
 	host		= process.env.HOST || "127.0.0.1",
 	port		= process.env.PORT || 3000,
+	pws			= process.env.PWS || "none",
 	app			= express();
 
-if ( !process.env.HOST || !process.env.PORT ) {
+if ( !process.env.HOST || !process.env.PORT || !process.env.LOCAL_PWS ) {
 	require( "dotenv" ).load();
 	host = process.env.HOST || host;
 	port = process.env.PORT || port;
+	pws = process.env.PWS || pws;
 }
 
 // Handle requests matching /weatherID.py where ID corresponds to the
@@ -20,6 +23,11 @@ app.get( /(\d+)/, weather.getWateringData );
 // Handle requests matching /weatherData
 app.options( /weatherData/, cors() );
 app.get( /weatherData/, cors(), weather.getWeatherData );
+
+// Endpoint to stream Weather Underground data from local PWS
+if ( pws === "WU" ) {
+	app.get( "/weatherstation/updateweatherstation.php", local.captureWUStream );
+}
 
 app.get( "/", function( req, res ) {
 	res.send( "OpenSprinkler Weather Service" );
@@ -34,6 +42,11 @@ app.use( function( req, res ) {
 // Start listening on the service port
 app.listen( port, host, function() {
 	console.log( "OpenSprinkler Weather Service now listening on %s:%s", host, port );
+
+	if (pws !== "none" ) {
+		console.log( "OpenSprinkler Weather Service now listening for local weather stream" );
+	}
 } );
 
 exports.app = app;
+exports.pws = pws;

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
-var express		= require( "express" ),
+var package		= require( "./package.json" ),
+	express		= require( "express" ),
 	weather		= require( "./routes/weather.js" ),
 	local		= require( "./routes/local.js" ),
 	cors		= require( "cors" ),
@@ -30,7 +31,7 @@ if ( pws === "WU" ) {
 }
 
 app.get( "/", function( req, res ) {
-	res.send( "OpenSprinkler Weather Service" );
+	res.send( package.description + " v" + package.version );
 } );
 
 // Handle 404 error
@@ -41,10 +42,10 @@ app.use( function( req, res ) {
 
 // Start listening on the service port
 app.listen( port, host, function() {
-	console.log( "OpenSprinkler Weather Service now listening on %s:%s", host, port );
+	console.log( "%s now listening on %s:%s", package.description, host, port );
 
 	if (pws !== "none" ) {
-		console.log( "OpenSprinkler Weather Service now listening for local weather stream" );
+		console.log( "%s now listening for local weather stream", package.description );
 	}
 } );
 


### PR DESCRIPTION
Samer, not sure if this is of interest but the PR adds a WU format endpoint to the weather service. This allows a local PWS to stream weather data directly to a locally hosted weather service where it can be served up to an OS weather request. The endpoint is only available if enabled in the .env file and so wouldn't be something that you and Ray would host but a possible solution for those with PWS that only provide a WU format stream. Happy to modify/adapt if you are interested but thought I would mention as I have referenced in the [Forum](https://opensprinkler.com/forums/topic/cutting-the-weather-underground-cord-homebrew-solution/)