### PR TITLE
Separate OWM calls for App and OS (draft)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .env
 coverage/*
 npm-debug.log
+.vscode
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/server.js
+++ b/server.js
@@ -14,12 +14,12 @@ if ( !process.env.HOST || !process.env.PORT ) {
 // Handle requests matching /weatherID.py where ID corresponds to the
 // weather adjustment method selector.
 // This endpoint is considered deprecated and supported for prior firmware
-app.get( /weather(\d+)\.py/, weather.getWeather );
-app.get( /(\d+)/, weather.getWeather );
+app.get( /weather(\d+)\.py/, weather.getWateringData );
+app.get( /(\d+)/, weather.getWateringData );
 
 // Handle requests matching /weatherData
 app.options( /weatherData/, cors() );
-app.get( /weatherData/, cors(), weather.showWeatherData );
+app.get( /weatherData/, cors(), weather.getWeatherData );
 
 app.get( "/", function( req, res ) {
 	res.send( "OpenSprinkler Weather Service" );


### PR DESCRIPTION
Hey Samer, I had some spare time and thought I'd have a go at updating the Weather Service based on the items mentioned in #12 and #13. I've badged this as draft since I don't have access to the OWM 16 Day Forecast (the paid service). I have tried it with the sample data from the OWM site but that is pretty limited.

Contains the following changes:
- Splits `getOWMWeatherData()` into two different functions to allow the OS and the App endpoints to use different OWM calls
- Uses two OWM api calls for requests for the App endpoint to provide the daily forecasts and also accurate current weather
 - Uses the OWM 3-Hour Forecast api for the OS endpoint as this is a free service and supports local installs of Weather Service
- Changes the Rain Delay logic to trigger when the next 3-hour forecast predicts rain rather than from the icon
 
Feel free to close this if you already have something in the works. But if of interest then let me know any feedback/thoughts and I can modify and do some more thorough testing. App would still need updating to cache the results and limit total number of api calls.