### PR TITLE
Harden against malformed api request

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You should see "OpenSprinkler Weather Service" in response.
 Secondly, you can use the following request to see the watering level that the Weather Service calculates. Note: to be consistent, change the values of h, t and r to the % weightings and bh (as a %), bt (in F), bp (in inches) to the offsets from the Zimmerman config page in App.
 
 ```
-http://<Weather Service IP>:3000/weather1.py?loc=50,1&wto="\"h\":100,\"t\":100,\"r\":100,\"bh\":70,\"bt\":59,\"br\":0"
+http://<Weather Service IP>:3000/weather1.py?loc=50,1&wto="h":100,"t":100,"r":100,"bh":70,"bt":59,"br":0
 ```
 
 This will return a response similar to below with ```scale``` value equating to the watering level and ```rawData``` reflecting the temp (F), humidity (%) and daily rainfall (inches) used in the zimmerman calc.

--- a/routes/weather.ts
+++ b/routes/weather.ts
@@ -242,8 +242,9 @@ export const getWateringData = async function( req: express.Request, res: expres
 		adjustmentOptions = JSON.parse( "{" + adjustmentOptionsString + "}" );
 	} catch ( err ) {
 
-		// If the JSON is not valid, do not incorporate weather adjustment options
-		adjustmentOptions = undefined;
+		// If the JSON is not valid then abort the claculation
+		res.send(`Error: Unable to parse options (${err})`);
+		return;
 	}
 
 	// Attempt to resolve provided location to GPS coordinates.


### PR DESCRIPTION
If `adjustmentOptions` are malformed then recommend "fail early" approach rather than continuing. Relates to #35 .