### PR TITLE
Add attribution to Watering Data

### DIFF
--- a/routes/adjustmentMethods/EToAdjustmentMethod.ts
+++ b/routes/adjustmentMethods/EToAdjustmentMethod.ts
@@ -54,6 +54,7 @@ async function calculateEToWateringScale(
 	return {
 		scale: scale,
 		rawData: {
+			weatherProvider: etoData.weatherProvider,
 			eto: Math.round( eto * 1000) / 1000,
 			radiation: Math.round( etoData.solarRadiation * 100) / 100,
 			minT: Math.round( etoData.minTemp ),

--- a/routes/adjustmentMethods/ManualAdjustmentMethod.ts
+++ b/routes/adjustmentMethods/ManualAdjustmentMethod.ts
@@ -7,6 +7,9 @@ import { AdjustmentMethod, AdjustmentMethodResponse } from "./AdjustmentMethod";
 async function calculateManualWateringScale( ): Promise< AdjustmentMethodResponse > {
 	return {
 		scale: undefined,
+		rawData: {
+			weatherProvider: "Manual",
+		},
 		wateringData: undefined
 	}
 }

--- a/routes/adjustmentMethods/RainDelayAdjustmentMethod.ts
+++ b/routes/adjustmentMethods/RainDelayAdjustmentMethod.ts
@@ -12,7 +12,10 @@ async function calculateRainDelayWateringScale( adjustmentOptions: RainDelayAdju
 	const d = adjustmentOptions.hasOwnProperty( "d" ) ? adjustmentOptions.d : 24;
 	return {
 		scale: undefined,
-		rawData: { raining: raining ? 1 : 0 },
+		rawData: {
+			weatherProvider: wateringData.weatherProvider,
+			raining: raining ? 1 : 0,
+			},
 		rainDelay: raining ? d : undefined,
 		wateringData: wateringData
 	}

--- a/routes/adjustmentMethods/ZimmermanAdjustmentMethod.ts
+++ b/routes/adjustmentMethods/ZimmermanAdjustmentMethod.ts
@@ -30,6 +30,7 @@ async function calculateZimmermanWateringScale(
 	*/
 
 	const rawData = {
+		weatherProvider: wateringData.weatherProvider,
 		h: wateringData ? Math.round( wateringData.humidity * 100) / 100 : null,
 		p: wateringData ? Math.round( wateringData.precip * 100 ) / 100 : null,
 		t: wateringData ? Math.round( wateringData.temp * 10 ) / 10 : null,


### PR DESCRIPTION
Include weather provider in ```rawData``` so that App can attribute watering calculation correctly. Added ```rawData``` to the manual adjustment method so that App can flag that manual settings are being used.

Related to App PR: [#87](https://github.com/OpenSprinkler/OpenSprinkler-App/pull/87)