### PR TITLE
Shift WUnderground to use precipTotal

### DIFF
--- a/routes/weatherProviders/WUnderground.ts
+++ b/routes/weatherProviders/WUnderground.ts
@@ -28,10 +28,12 @@ export default class WUnderground extends WeatherProvider {
 		}
 
 		const totals = { temp: 0, humidity: 0, precip: 0 };
+		let lastPrecip = samples[0].imperial.precipTotal;
 		for ( const sample of samples ) {
 			totals.temp += sample.imperial.tempAvg;
 			totals.humidity += sample.humidityAvg;
-			totals.precip += sample.imperial.precipRate;
+			totals.precip += ( sample.imperial.precipTotal - lastPrecip > 0 ) ? sample.imperial.precipTotal - lastPrecip : 0;
+			lastPrecip = sample.imperial.precipTotal
 		}
 
 		return {


### PR DESCRIPTION
Reference discussion on Discord: [here](https://openthingsio.slack.com/archives/C3639602E/p1570967053032700)







Looks like using `precipRate` results in an over estimate of the total rainfall during the period. Particularly, if there is heavy rainfall at the moment of the observation. The WU site says:

> precipRate = Rate of precipitation - instantaneous precipitation rate. How much rain would fall if the precipitation intensity did not change for one hour

This PR swaps to using `precipTotal` and calculating the difference between periods. Note that the total resets to zero at midnight so this approach will lose any rain that falls between the last reading of the day and midnight.