### PR TITLE
Add PWS support to RainDelay adjustment method

### DIFF
--- a/routes/adjustmentMethods/RainDelayAdjustmentMethod.ts
+++ b/routes/adjustmentMethods/RainDelayAdjustmentMethod.ts
@@ -1,13 +1,18 @@
 import { AdjustmentMethod, AdjustmentMethodResponse, AdjustmentOptions } from "./AdjustmentMethod";
-import { GeoCoordinates, ZimmermanWateringData } from "../../types";
+import { GeoCoordinates, PWS, ZimmermanWateringData } from "../../types";
 import { WeatherProvider } from "../weatherProviders/WeatherProvider";
 
 
 /**
  * Only delays watering if it is currently raining and does not adjust the watering scale.
  */
-async function calculateRainDelayWateringScale( adjustmentOptions: RainDelayAdjustmentOptions, coordinates: GeoCoordinates, weatherProvider: WeatherProvider ): Promise< AdjustmentMethodResponse > {
-	const wateringData: ZimmermanWateringData = await weatherProvider.getWateringData( coordinates );
+async function calculateRainDelayWateringScale(
+	adjustmentOptions: RainDelayAdjustmentOptions,
+	coordinates: GeoCoordinates,
+	weatherProvider: WeatherProvider,
+	pws?: PWS
+): Promise< AdjustmentMethodResponse > {
+	const wateringData: ZimmermanWateringData = await weatherProvider.getWateringData( coordinates, pws );
 	const raining = wateringData && wateringData.raining;
 	const d = adjustmentOptions.hasOwnProperty( "d" ) ? adjustmentOptions.d : 24;
 	return {


### PR DESCRIPTION
If WUnderground API key and PWS is configured in Firmware then Weather Service would still generate a "No PWS Provided" error when RainDelay method was called. This PR adds PWS optional parameter to adjustment method so that `raining` condition can be detected.
