### PR TITLE
docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node
+
+EXPOSE 3000
+
+RUN groupadd osweather && useradd --no-log-init -m -g osweather osweather
+USER osweather
+
+ADD --chown=osweather:osweather . weather
+
+WORKDIR weather
+RUN npm install
+RUN npm run compile
+CMD npm start
+

--- a/README.md
+++ b/README.md
@@ -60,3 +60,24 @@ For more information on the "WeeWX Solution" click [here](docs/weewx.md)
 
 - Davis Vantage: a solution for this PWS has been kindly provided by @rmloeb [here](docs/davis-vantage.md)
 - Netatmo: instructions for configuring this PWS have been greatfully provided by @franzstein [here](docs/netatmo.md)
+
+## Docker
+
+It is possible to build a self-contained docker image from this repository.  It can then be used to run the service
+without installing any prerequisites or setting up systemd.
+
+### Building the Docker image
+```shell script
+./build-docker.sh  # run with -h for other options
+```
+The above will generate baselineEtoData (if not already done) and then build a complete opensprinkler-weather docker image.
+
+### Running the Docker image
+```shell script
+docker create --name=osweather -p 3000:3000 --restart unless-stopped opensprinkler-weather
+docker start osweather
+
+# Instead of the above, use this for testing/troubleshooting by running it in the foreground:
+docker run --rm -it -p 3000:3000 opensprinkler-weather
+```
+Note: to expose a different port, change `-p 3000:3000` to, eg `-p12345:3000` 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+
+while getopts ":hp:r" opt; do
+  case ${opt} in
+    h )
+      echo "Usage:"
+      echo "    -h                    Display this help message."
+      echo "    -p 20                 Use 20 passes when generating baseline ETo data (20 is default)."
+      echo "    -r                    Force regeneration of baseline ETo data even if file exists"
+      exit 0
+      ;;
+    p )
+      PASSES=$OPTARG
+      echo "Using $PASSES passes for ETo data.  Pass -r to force regeneration"
+      ;;
+    r )
+      echo "Forcing a rebuild of ETo data"
+      REBUILD=true
+      ;;
+    \? )
+      echo "Invalid Option: -$OPTARG" 1>&2
+      exit 1
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+if [ ! -f baselineEToData/Baseline_ETo_Data.bin ] || [ -n "$REBUILD" ] ; then
+  echo "Building ETo Data"
+  cd baselineEToData
+  docker build -t baseline-eto-data-preparer . && docker run --rm -v $(pwd):/output baseline-eto-data-preparer $PASSES
+  cd -
+else
+  echo "Not generating baselineEToData, file already exists"
+fi
+
+if [ ! -f .env ] ; then
+  echo "Please create a .env configuration file in this directory before running"
+  echo "See https://github.com/OpenSprinkler/OpenSprinkler-Weather/blob/master/docs/local-installation.md for examples"
+  echo "Ensure that it contains the following: (default PORT is fine)"
+  echo " HOST=0.0.0.0"
+  exit 1
+fi
+
+if ! grep 'HOST=0.0.0.0' .env > /dev/null ; then
+  echo "Please ensure that your .env file contains 'HOST=0.0.0.0' in addition to other configuration options"
+  exit 1
+fi
+
+docker build -t opensprinkler-weather .


### PR DESCRIPTION
Makes it possible to build a self-contained docker image from this repository.  It can then be used to run the service
without installing any prerequisites, messing with npm install, or setting up systemd.