### PR TITLE
Update geotz

### DIFF
--- a/WateringScaleCache.ts
+++ b/WateringScaleCache.ts
@@ -27,7 +27,7 @@ export default class WateringScaleCache {
 		wateringScale: CachedScale
 	): void {
 		// The end of the day in the controller's timezone.
-		const expirationDate: Moment = moment().tz( geoTZ( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ] ).endOf( "day" );
+		const expirationDate: Moment = moment().tz( geoTZ.find( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ] ).endOf( "day" );
 		const ttl: number = ( expirationDate.unix() - moment().unix() );
 		const key = this.makeKey( adjustmentMethodId, coordinates, pws, adjustmentOptions );
 		this.cache.set( key, wateringScale, ttl );

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
         "cron": "^1.3.0",
         "dotenv": "^8.0.0",
         "express": "^4.16.4",
-        "geo-tz": "^5.0.4",
+        "geo-tz": "^8.1.4",
         "jsonwebtoken": "^9.0.0",
         "mockdate": "^2.0.2",
-        "moment-timezone": "^0.5.25",
+        "moment-timezone": "^0.5.48",
         "node-cache": "^4.2.0",
         "suncalc": "^1.8.0"
       },
@@ -38,29 +38,47 @@
         "node-watch": "^0.6.2",
         "nodemon": "^2.0.16",
         "ts-node": "^8.1.0",
-        "typescript": "^3.4.5"
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@turf/boolean-point-in-polygon": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz",
-      "integrity": "sha512-FKLOZ124vkJhjzNSDcqpwp2NvfnsbYoUOt5iAE7uskt4svix5hcjIEgX9sELFTJpbLGsD1mUbKdfns8tZxcMNg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-7.2.0.tgz",
+      "integrity": "sha512-lvEOjxeXIp+wPXgl9kJA97dqzMfNexjqHou+XHVcfxQgolctoJiRYmcVCWGpiZ9CBf/CJha1KmD1qQoRIsjLaA==",
       "dependencies": {
-        "@turf/helpers": "6.x",
-        "@turf/invariant": "6.x"
+        "@turf/helpers": "^7.2.0",
+        "@turf/invariant": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "point-in-polygon-hao": "^1.1.0",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@turf/helpers": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
-      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
     },
     "node_modules/@turf/invariant": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz",
-      "integrity": "sha512-WU08Ph8j0J2jVGlQCKChXoCtI50BB3yEH21V++V0T4cR1T27HKCxkehV2sYMwTierfMBgjwSwDIsxnR4/2mWXg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-7.2.0.tgz",
+      "integrity": "sha512-kV4u8e7Gkpq+kPbAKNC21CmyrXzlbBgFjO1PhrHPgEdNqXqDawoZ3i6ivE3ULJj2rSesCjduUaC/wyvH/sNr2Q==",
       "dependencies": {
-        "@turf/helpers": "6.x"
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@types/body-parser": {
@@ -136,6 +154,11 @@
         "@types/node": "*",
         "@types/range-parser": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
     },
     "node_modules/@types/mime": {
       "version": "2.0.1",
@@ -512,9 +535,9 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -523,16 +546,16 @@
       "dev": true
     },
     "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
-        "node >= 0.8"
+        "node >= 6.0"
       ],
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
       }
     },
@@ -564,11 +587,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -762,7 +780,7 @@
     "node_modules/file-source": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/file-source/-/file-source-0.6.1.tgz",
-      "integrity": "sha1-rhidSZN2a4Zad/g63Pm5pQTNN9w=",
+      "integrity": "sha512-1R1KneL7eTXmXfKxC10V/9NeGOdbsAXJ+lQ//fvvcHUgtaZcZDWNJNblxAoVOyV1cj45pOtUrR3vZTBwqcW8XA==",
       "dependencies": {
         "stream-source": "0.3"
       }
@@ -858,27 +876,29 @@
       }
     },
     "node_modules/geo-tz": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/geo-tz/-/geo-tz-5.0.4.tgz",
-      "integrity": "sha512-gBpvO0bkAajQ17tFobbOjoJur1YRHxIE+AsR+uGd6gfnzRyOxpq4jk62aX7UNjuGEzwGn95DrblEod56K9e1vw==",
+      "version": "8.1.4",
+      "resolved": "https://registry.npmjs.org/geo-tz/-/geo-tz-8.1.4.tgz",
+      "integrity": "sha512-xayeOC05wgy6JATU/k7GFHTMfSimzL1Fi3KSzt2GqvEnP1ZFXyQ9V4VAiTrTYhZSmRr0dbchZkximSegHZNUfA==",
       "dependencies": {
-        "@turf/boolean-point-in-polygon": "^6.0.1",
-        "@turf/helpers": "^6.1.3",
-        "geobuf": "^3.0.0",
-        "pbf": "^3.0.5",
-        "timed-cache": "^1.1.0"
+        "@turf/boolean-point-in-polygon": "^7.1.0",
+        "@turf/helpers": "^7.1.0",
+        "geobuf": "^3.0.2",
+        "pbf": "^3.2.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/evansiroky"
       }
     },
     "node_modules/geobuf": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/geobuf/-/geobuf-3.0.1.tgz",
-      "integrity": "sha512-6gwj0B9oJaOVcG1HFliN/nmsUFq4FRlVmMKyykQ7lV574PeRHJH6ByB7HZtwztpDzJc8RJHUQhH5jH7Sg6EYvA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/geobuf/-/geobuf-3.0.2.tgz",
+      "integrity": "sha512-ASgKwEAQQRnyNFHNvpd5uAwstbVYmiTW0Caw3fBb509tNTqXyAAPMyFs5NNihsLZhLxU1j/kjFhkhLWA9djuVg==",
       "dependencies": {
-        "concat-stream": "^1.6.2",
-        "pbf": "^3.1.0",
+        "concat-stream": "^2.0.0",
+        "pbf": "^3.2.1",
         "shapefile": "~0.6.6"
       },
       "bin": {
@@ -975,9 +995,23 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "node_modules/ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -1426,19 +1460,19 @@
       "integrity": "sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI="
     },
     "node_modules/moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.25",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.25.tgz",
-      "integrity": "sha512-DgEaTyN/z0HFaVcVbSyVCUU6HeFdnNC3vE4c9cgu2dgMTvjBUBdBzWfasTBmAW45u5OIMeCJtU8yNjM22DHucw==",
+      "version": "0.5.48",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+      "integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
       "dependencies": {
-        "moment": ">= 2.9.0"
+        "moment": "^2.29.4"
       },
       "engines": {
         "node": "*"
@@ -1708,9 +1742,9 @@
       }
     },
     "node_modules/pbf": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.0.tgz",
-      "integrity": "sha512-98Eh7rsJNJF/Im6XYMLaOW3cLnNyedlOd6hu3iWMD5I7FZGgpw8yN3vQBrmLbLodu7G784Irb9Qsv2yFrxSAGw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -1731,10 +1765,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    "node_modules/point-in-polygon-hao": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/point-in-polygon-hao/-/point-in-polygon-hao-1.2.4.tgz",
+      "integrity": "sha512-x2pcvXeqhRHlNRdhLs/tgFapAbSSe86wa/eqmj1G6pWftbEs5aVRJhRGM6FYSUERKu0PjekJzMq0gsI2XyiclQ==",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/propagate": {
       "version": "1.0.0",
@@ -1746,9 +1783,9 @@
       ]
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.5",
@@ -1819,30 +1856,16 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "node_modules/readable-stream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -1873,6 +1896,11 @@
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -1985,7 +2013,7 @@
     "node_modules/slice-source": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
-      "integrity": "sha1-QKV6wDxmaLXaIA4FN44AC/KmHXk="
+      "integrity": "sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -2018,6 +2046,33 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/stream-source/-/stream-source-0.3.5.tgz",
       "integrity": "sha512-ZuEDP9sgjiAwUVoDModftG0JtYiLUV8K4ljYD1VyUMRWtbVf92474o4kuuul43iZ8t/hRuiDAx1dIJSvirrK/g=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2080,13 +2135,8 @@
     "node_modules/text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "integrity": "sha512-hJnc6Qg3dWoOMkqP53F0dzRIgtmsAge09kxUIqGrEUS4qr5rWLckGYaQAVr+opBrIMRErGgy6f5aPnyPpyGRfg==",
       "deprecated": "no longer maintained"
-    },
-    "node_modules/timed-cache": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/timed-cache/-/timed-cache-1.1.1.tgz",
-      "integrity": "sha512-ADZmeElmScZLH1TBrEB7ERTeoXZ+7JfTkcz2Z4AjhaJXLCyceK3LF1LEWm/tGUjcfdPKAM+eJCy7RM4dQqYH/g=="
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -2149,6 +2199,11 @@
         "typescript": ">=2.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -2184,19 +2239,19 @@
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "3.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
-      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/undefsafe": {
@@ -2216,7 +2271,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "cron": "^1.3.0",
     "dotenv": "^8.0.0",
     "express": "^4.16.4",
-    "geo-tz": "^5.0.4",
+    "geo-tz": "^8.1.4",
     "jsonwebtoken": "^9.0.0",
     "mockdate": "^2.0.2",
-    "moment-timezone": "^0.5.25",
+    "moment-timezone": "^0.5.48",
     "node-cache": "^4.2.0",
     "suncalc": "^1.8.0"
   },
@@ -43,6 +43,6 @@
     "node-watch": "^0.6.2",
     "nodemon": "^2.0.16",
     "ts-node": "^8.1.0",
-    "typescript": "^3.4.5"
+    "typescript": "^5.8.3"
   }
 }

--- a/routes/weather.ts
+++ b/routes/weather.ts
@@ -93,7 +93,7 @@ export async function httpJSONRequest(url: string, headers?, body?): Promise< an
  * @return The TimeData for the specified coordinates.
  */
 function getTimeData( coordinates: GeoCoordinates ): TimeData {
-	const timezone = moment().tz( geoTZ( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ] ).utcOffset();
+	const timezone = moment().tz( geoTZ.find( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ] ).utcOffset();
 	const tzOffset: number = getTimezone( timezone, true );
 
 	// Calculate sunrise and sunset since Weather Underground does not provide it

--- a/routes/weatherProviders/Apple.ts
+++ b/routes/weatherProviders/Apple.ts
@@ -15,6 +15,7 @@ export default class AppleWeatherProvider extends WeatherProvider {
 		super();
 
         if (!process.env.APPLE_PRIVATE_KEY) {
+            return;
 			throw "APPLE_PRIVATE_KEY environment variable is not defined.";
 		}
 

--- a/routes/weatherProviders/OWM.ts
+++ b/routes/weatherProviders/OWM.ts
@@ -21,7 +21,7 @@ export default class OWMWeatherProvider extends WeatherProvider {
 
 		// The OWM free API options changed so need to use the new API method
 		//Get previous date by using UTC
-		const timezone = moment().tz( geoTZ( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ] ).utcOffset();
+		const timezone = moment().tz( geoTZ.find( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ] ).utcOffset();
 		let time = Date.now();
 		time -= (86400000 + timezone * 3600);
 		const date = new Date(time);
@@ -115,7 +115,7 @@ export default class OWMWeatherProvider extends WeatherProvider {
 
 		// The OWM API changed what you get on the free subscription so need to adjust the call and translate the data.
 		//Get previous date by using UTC
-		const timezone = moment().tz( geoTZ( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ] ).utcOffset();
+		const timezone = moment().tz( geoTZ.find( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ] ).utcOffset();
 		let time = Date.now();
 		time -= (86400000 + timezone * 3600);
 		const date = new Date(time);

--- a/routes/weatherProviders/OpenMeteo.ts
+++ b/routes/weatherProviders/OpenMeteo.ts
@@ -71,7 +71,7 @@ export default class OpenMeteoWeatherProvider extends WeatherProvider {
 		//console.log("OM getWeatherData request for coordinates: %s", coordinates);
 
 		const currentDate: number = moment().unix();
-		const timezone = geoTZ( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ];
+		const timezone = geoTZ.find( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ];
 
 		const currentUrl = `https://api.open-meteo.com/v1/forecast?latitude=${ coordinates[ 0 ] }&longitude=${ coordinates[ 1 ] }&timezone=${ timezone }&daily=weathercode,temperature_2m_max,temperature_2m_min,precipitation_sum,windspeed_10m_max&current_weather=true&temperature_unit=fahrenheit&windspeed_unit=mph&precipitation_unit=inch&timeformat=unixtime`;
 		//console.log(currentUrl);
@@ -126,7 +126,7 @@ export default class OpenMeteoWeatherProvider extends WeatherProvider {
 		//console.log("OM getEToData request for coordinates: %s", coordinates);
 
 		const timestamp: string = moment().subtract( 1, "day" ).format();
-		const timezone = geoTZ( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ];
+		const timezone = geoTZ.find( coordinates[ 0 ], coordinates[ 1 ] )[ 0 ];
 		const historicUrl = `https://api.open-meteo.com/v1/forecast?latitude=${ coordinates[ 0 ] }&longitude=${ coordinates[ 1 ] }&timezone=${ timezone }&hourly=temperature_2m,relativehumidity_2m,precipitation,direct_radiation,windspeed_10m&temperature_unit=fahrenheit&windspeed_unit=mph&precipitation_unit=inch&timeformat=unixtime&past_days=1`;
 		//console.log(historicUrl);
 


### PR DESCRIPTION
Closes #160 
Closes OpenSprinkler/OpenSprinkler-Firmware/#354

This PR updates geotz package to fix the time zone issue reported in OpenSprinkler-Firmware/#354. Also addresses issue #160 by not requiring Apple key.